### PR TITLE
Fused backward pass kernel

### DIFF
--- a/accelerated_scan/warp.cuh
+++ b/accelerated_scan/warp.cuh
@@ -356,6 +356,8 @@ __device__ Tuple load_shifted_tuple(const Tuple* ptr, int index, int limit) {
         const int idx = index * Tuple::Size + i + offset;
         if (idx >= 0 && idx < limit * Tuple::Size) {
             x.data[i] = rawPtr[offset];
+        } else {
+            x.data[i] = 0;
         }
     }
 

--- a/accelerated_scan/warp.cuh
+++ b/accelerated_scan/warp.cuh
@@ -4,6 +4,8 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <torch/extension.h>
 
+#define CHECK_STRIDE(x) TORCH_CHECK(x.stride(-1) == 1 || x.size(-1) == 1);
+
 template<typename weight_t, int N>
 class UnalignedTuple {
 public:
@@ -209,8 +211,8 @@ warpscan(const at::Tensor &gates, const at::Tensor &tokens, const at::Tensor &ou
     const auto strides = tokens.strides();
     const int batch_stride = strides[0];
     const int dim_stride = strides[1];
-    TORCH_CHECK(tokens.stride(-1) == 1 || tokens.size(-1) == 1);
-    TORCH_CHECK(gates.stride(-1) == 1 || gates.size(-1) == 1);
+    CHECK_STRIDE(tokens);
+    CHECK_STRIDE(gates);
 
     const auto sizes = tokens.sizes();
     const int batch_size = sizes[0];
@@ -338,6 +340,372 @@ warpscan_forward(const at::Tensor &gates, const at::Tensor &tokens, const at::Te
     } else if (tokens.scalar_type() == at::ScalarType::Float) {
         TORCH_CHECK(gates.scalar_type() == at::ScalarType::Float);
         warpscan<float, float>(gates, tokens, out, reverse);
+    } else {
+        TORCH_CHECK(false && "Unsupported tensor dtype: expecting bfloat16, float16 or float32");
+    }
+    return out;
+}
+
+template <typename Tuple, int offset>
+Tuple load_shifted_tuple(const Tuple* ptr, int index, int limit) {
+    using weight_t = typename Tuple::Type;
+
+    const weight_t* rawPtr = reinterpret_cast<const weight_t *>(ptr);
+    Tuple x;
+    for (int i = 0; i < Tuple::Size; i++) {
+        const int offset = index*4 + i + offset;
+        if (offset >= 0 && offset < limit*4) {
+            x.data[i] = rawPtr[offset];
+        }
+    }
+
+    return x;
+}
+
+template <typename Tuple, int kNThreadsPerWarp, int kNWarpsPerBlock, int kNChunksPerSequence>
+__global__ void scan_grad(
+    const Tuple* gates,
+    const Tuple* output,
+    const Tuple* outGrad,
+    Tuple* gateGradOut,
+    Tuple* valueGradOut,
+    const int batch_stride,
+    const int dim_stride,
+    const bool reverse
+) {
+    using weight_t = typename Tuple::Type;
+
+    __shared__ weight_t warpLastGate[kNWarpsPerBlock];
+    __shared__ weight_t warpLastToken[kNWarpsPerBlock];
+    __shared__ weight_t chunkAccGate, chunkAccToken;
+
+    const int seqoffset = blockIdx.x * batch_stride + blockIdx.y * dim_stride;
+    const int warpId = threadIdx.x / kNThreadsPerWarp;
+    const int laneId = threadIdx.x % kNThreadsPerWarp;
+    const int chunklen = blockDim.x * Tuple::Size;
+    constexpr int kBlockLast = kNWarpsPerBlock - 1;
+    constexpr int kWarpLast = kNThreadsPerWarp - 1;
+    constexpr int kThreadLast = Tuple::Size - 1;
+    const weight_t kEmptyGate = 1.0;
+    const weight_t kEmptyToken = 0.0;
+    const int limit = blockDim.x * kNChunksPerSequence;
+
+    for (int chunk = 0; chunk < kNChunksPerSequence; chunk++) {
+        const int offset = seqoffset + (kNChunksPerSequence - 1 - chunk) * chunklen;
+        const int tupleOffset = (offset + (chunklen - ((threadIdx.x + 1) * Tuple::Size))) / Tuple::Size;
+
+        if (chunk) {
+            __syncthreads();
+        }
+
+        // Load from global memory.
+        Tuple loadedGate = load_shifted_tuple<Tuple, 1>(gates, tupleOffset, limit);
+        Tuple loadedToken = outGrad[tupleOffset];
+        loadedGate.reverse();
+        loadedToken.reverse();
+
+        Tuple accGate;
+        Tuple accToken;
+
+        // Scan within the current thread.
+        #pragma unroll
+        for (int i = 0; i < Tuple::Size; ++i) {
+            weight_t gate = loadedGate.data[i];
+            weight_t token = loadedToken.data[i];
+            if (i == 0) {
+                if (chunk == 0) {
+                    accGate.data[0] = threadIdx.x == 0 ? kEmptyGate : gate;
+                    accToken.data[0] = token;
+                } else {
+                    if (threadIdx.x == 0) {
+                        // Add the last element of the previous chunk to the first element of the current chunk.
+                        accGate.data[0] = chunkAccGate * gate;
+                        accToken.data[0] = chunkAccToken * gate + token;
+                    } else {
+                        accGate.data[0] = gate;
+                        accToken.data[0] = token;
+                    }
+                }
+            } else {
+                accGate.data[i] = accGate.data[i - 1] * gate;
+                accToken.data[i] = accToken.data[i - 1] * gate + token;
+            }
+        }
+
+        //
+        // Scan threads in a warp using shuffling (level 1).
+        //
+
+        #pragma unroll
+        for (int delta = 1; delta < kNThreadsPerWarp; delta *= 2) {
+            weight_t prev_gate = __shfl_up_sync(0xffffffff, accGate.data[kThreadLast], delta);
+            weight_t prev_token = __shfl_up_sync(0xffffffff, accToken.data[kThreadLast], delta);
+
+            if (laneId >= delta) {
+                #pragma unroll
+                for (int i = 0; i < Tuple::Size; ++i) {
+                    accToken.data[i] = prev_token * accGate.data[i] + accToken.data[i];
+                    accGate.data[i] = prev_gate * accGate.data[i];
+                }
+            }
+        }
+
+        __syncwarp();
+
+        //
+        // Store the last element of each warp in shared memory.
+        //
+
+        if (laneId == kWarpLast) {
+            warpLastGate[warpId] = accGate.data[kThreadLast];
+            warpLastToken[warpId] = accToken.data[kThreadLast];
+        }
+
+        __syncthreads();
+
+        //
+        // Leading warp scans every warp in a block (level 2).
+        //
+
+        if (warpId == 0) {
+            weight_t warpAccGate, warpAccToken;
+            warpAccGate = (laneId < kNWarpsPerBlock) ? warpLastGate[laneId] : kEmptyGate;
+            warpAccToken = (laneId < kNWarpsPerBlock) ? warpLastToken[laneId] : kEmptyToken;
+
+            #pragma unroll
+            for (int delta = 1; delta < warpSize; delta *= 2) {
+                weight_t prev_gate = __shfl_up_sync(0xffffffff, warpAccGate, delta);
+                weight_t prev_token = __shfl_up_sync(0xffffffff, warpAccToken, delta);
+
+                if (laneId >= delta) {
+                    warpAccToken = prev_token * warpAccGate + warpAccToken;
+                    warpAccGate = prev_gate * warpAccGate;
+                }
+            }
+
+            if (laneId < kNWarpsPerBlock) {
+                warpLastGate[laneId] = warpAccGate;
+                warpLastToken[laneId] = warpAccToken;
+            }
+        }
+
+        __syncthreads();
+
+        //
+        // Add the last element of the previous warp to each element of the current warp (level 0).
+        // Store to global memory.
+        //
+
+        #pragma unroll
+        for (int i = 0; i < Tuple::Size; ++i) {
+            if (warpId > 0) {
+                accToken.data[i] = warpLastToken[warpId-1] * accGate.data[i] + accToken.data[i];
+                accGate.data[i] = warpLastGate[warpId-1] * accGate.data[i];
+            }
+        }
+        if (reverse) {
+            accToken.reverse();
+        }
+        valueGradOut[tupleOffset] = accToken;
+
+        Tuple gateGrad = load_shifted_tuple<Tuple, -1>(output, tupleOffset, limit);
+        for (int i = 0; i < Tuple::Size; i++) {
+            gateGrad.data[i] *= accToken.data[i];
+        }
+        gateGradOut[tupleOffset] = gateGrad;
+
+        if (laneId == kWarpLast && warpId == kBlockLast) {
+            chunkAccGate = accGate.data[kThreadLast];
+            chunkAccToken = accToken.data[kThreadLast];
+        }
+    }
+}
+
+#define DISPATCH_SCAN_GRAD(weight_t, kNStepsPerThread, kNThreadsPerWarp, kNWarpsPerBlock, kNChunksPerSequence, grid, kNThreads, stream, gates, output, outGrad, gateGradOut, valueGradOut, batch_stride, dim_stride, reverse) \
+    using AlignedT = AlignedTuple<weight_t, kNStepsPerThread>; \
+    using UnalignedT = UnalignedTuple<weight_t, kNStepsPerThread>; \
+    if (kNStepsPerThread == 4 && \
+        ((long)gates.data_ptr()) % 16 == 0 && \
+        ((long)output.data_ptr()) % 16 == 0 && \
+        ((long)outGrad.data_ptr()) % 16 == 0 && \
+        ((long)gateGradOut.data_ptr()) % 16 == 0 && \
+        ((long)valueGradOut.data_ptr()) % 16 == 0) { \
+        scan_grad<AlignedT, kNThreadsPerWarp, kNWarpsPerBlock, kNChunksPerSequence><<<grid, kNThreads, kNWarpsPerBlock * sizeof(weight_t) * 2, stream>>>( \
+                reinterpret_cast<const AlignedT *>(gates.data_ptr<torch_weight_t>()), \
+                reinterpret_cast<const AlignedT *>(output.data_ptr<torch_weight_t>()), \
+                reinterpret_cast<const AlignedT *>(outGrad.data_ptr<torch_weight_t>()), \
+                reinterpret_cast<const AlignedT *>(gateGradOut.data_ptr<torch_weight_t>()), \
+                reinterpret_cast<AlignedT *>(valueGradOut.data_ptr<torch_weight_t>()), \
+                batch_stride, dim_stride, reverse \
+            ); \
+    } else { \
+        scan_grad<UnalignedT, kNThreadsPerWarp, kNWarpsPerBlock, kNChunksPerSequence><<<grid, kNThreads, kNWarpsPerBlock * sizeof(weight_t) * 2, stream>>>( \
+                reinterpret_cast<const UnalignedT*>(gates.data_ptr<torch_weight_t>()), \
+                reinterpret_cast<const UnalignedT*>(output.data_ptr<torch_weight_t>()), \
+                reinterpret_cast<const UnalignedT*>(outGrad.data_ptr<torch_weight_t>()), \
+                reinterpret_cast<const UnalignedT*>(gateGradOut.data_ptr<torch_weight_t>()), \
+                reinterpret_cast<UnalignedT *>(valueGradOut.data_ptr<torch_weight_t>()), \
+                batch_stride, dim_stride, reverse \
+            ); \
+    }
+
+template <typename weight_t, typename torch_weight_t>
+void
+warpscan_grad(const at::Tensor &gates, const at::Tensor &output, const at::Tensor &outGrad,
+              const at::Tensor& gateGradOut, const at::Tensor& valueGradOut) {
+    const auto strides = tokens.strides();
+    const int batch_stride = strides[0];
+    const int dim_stride = strides[1];
+    CHECK_STRIDE(gates);
+    CHECK_STRIDE(output);
+    CHECK_STRIDE(outGrad);
+    CHECK_STRIDE(gateGradOut);
+    CHECK_STRIDE(valueGradOut);
+
+    const auto sizes = tokens.sizes();
+    const int batch_size = sizes[0];
+    const int dim = sizes[1];
+    const int seqlen = sizes[2];
+
+    auto stream = at::cuda::getCurrentCUDAStream().stream();
+    dim3 grid(batch_size, dim);
+    constexpr int kNThreadsPerWarp = 32;
+
+    if (seqlen == 32) {
+        constexpr int kNStepsPerThread = 1;
+        constexpr int kNWarpsPerBlock = 1;
+        int kNThreads = seqlen / kNStepsPerThread;
+        constexpr int kNChunksPerSequence = 1;
+        DISPATCH_SCAN_GRAD(weight_t, kNStepsPerThread, kNThreadsPerWarp, kNWarpsPerBlock,
+            kNChunksPerSequence, grid, kNThreads, stream,
+            gates, output, outGrad, gateGradOut, valueGradOut,
+            batch_stride, dim_stride, reverse);
+    } else if (seqlen == 64) {
+        constexpr int kNStepsPerThread = 2;
+        constexpr int kNWarpsPerBlock = 1;
+        constexpr int kNChunksPerSequence = 1;
+        int kNThreads = seqlen / kNStepsPerThread / kNChunksPerSequence;
+        DISPATCH_SCAN(weight_t, kNStepsPerThread, kNThreadsPerWarp, kNWarpsPerBlock,
+            kNChunksPerSequence, grid, kNThreads, stream,
+            gates, output, outGrad, gateGradOut, valueGradOut,
+            batch_stride, dim_stride, reverse);
+    } else if (seqlen == 128) {
+        constexpr int kNStepsPerThread = 1;
+        constexpr int kNWarpsPerBlock = 4;
+        int kNThreads = seqlen / kNStepsPerThread;
+        constexpr int kNChunksPerSequence = 1;
+        DISPATCH_SCAN(weight_t, kNStepsPerThread, kNThreadsPerWarp, kNWarpsPerBlock,
+            kNChunksPerSequence, grid, kNThreads, stream,
+            gates, output, outGrad, gateGradOut, valueGradOut,
+            batch_stride, dim_stride, reverse);
+    } else if (seqlen == 256) {
+        constexpr int kNStepsPerThread = 1;
+        constexpr int kNWarpsPerBlock = 8;
+        int kNThreads = seqlen / kNStepsPerThread;
+        constexpr int kNChunksPerSequence = 1;
+        DISPATCH_SCAN(weight_t, kNStepsPerThread, kNThreadsPerWarp, kNWarpsPerBlock,
+            kNChunksPerSequence, grid, kNThreads, stream,
+            gates, output, outGrad, gateGradOut, valueGradOut,
+            batch_stride, dim_stride, reverse);
+    } else if (seqlen == 512) {
+        constexpr int kNStepsPerThread = 1;
+        constexpr int kNWarpsPerBlock = 16;
+        int kNThreads = seqlen / kNStepsPerThread;
+        constexpr int kNChunksPerSequence = 1;
+        DISPATCH_SCAN(weight_t, kNStepsPerThread, kNThreadsPerWarp, kNWarpsPerBlock,
+            kNChunksPerSequence, grid, kNThreads, stream,
+            gates, output, outGrad, gateGradOut, valueGradOut,
+            batch_stride, dim_stride, reverse);
+    } else if (seqlen == 1024) {
+        constexpr int kNStepsPerThread = 2;
+        constexpr int kNWarpsPerBlock = 16;
+        int kNThreads = seqlen / kNStepsPerThread;
+        constexpr int kNChunksPerSequence = 1;
+        DISPATCH_SCAN(weight_t, kNStepsPerThread, kNThreadsPerWarp, kNWarpsPerBlock,
+            kNChunksPerSequence, grid, kNThreads, stream,
+            gates, output, outGrad, gateGradOut, valueGradOut,
+            batch_stride, dim_stride, reverse);
+    } else if (seqlen == 2048) {
+        constexpr int kNStepsPerThread = 2;
+        constexpr int kNWarpsPerBlock = 32;
+        int kNThreads = seqlen / kNStepsPerThread;
+        constexpr int kNChunksPerSequence = 1;
+        DISPATCH_SCAN(weight_t, kNStepsPerThread, kNThreadsPerWarp, kNWarpsPerBlock,
+            kNChunksPerSequence, grid, kNThreads, stream,
+            gates, output, outGrad, gateGradOut, valueGradOut,
+            batch_stride, dim_stride, reverse);
+    } else if (seqlen == 4096) {
+        constexpr int kNStepsPerThread = 4;
+        constexpr int kNWarpsPerBlock = 32;
+        int kNThreads = seqlen / kNStepsPerThread;
+        constexpr int kNChunksPerSequence = 1;
+        DISPATCH_SCAN(weight_t, kNStepsPerThread, kNThreadsPerWarp, kNWarpsPerBlock,
+            kNChunksPerSequence, grid, kNThreads, stream,
+            gates, output, outGrad, gateGradOut, valueGradOut,
+            batch_stride, dim_stride, reverse);
+    } else if (seqlen == 8192) {
+        constexpr int kNStepsPerThread = 4;
+        constexpr int kNWarpsPerBlock = 32;
+        constexpr int kNChunksPerSequence = 2;
+        int kNThreads = seqlen / kNStepsPerThread / kNChunksPerSequence;
+        DISPATCH_SCAN(weight_t, kNStepsPerThread, kNThreadsPerWarp, kNWarpsPerBlock,
+            kNChunksPerSequence, grid, kNThreads, stream,
+            gates, output, outGrad, gateGradOut, valueGradOut,
+            batch_stride, dim_stride, reverse);
+    } else if (seqlen == 16384) {
+        constexpr int kNStepsPerThread = 4;
+        constexpr int kNWarpsPerBlock = 32;
+        constexpr int kNChunksPerSequence = 4;
+        int kNThreads = seqlen / kNStepsPerThread / kNChunksPerSequence;
+        DISPATCH_SCAN(weight_t, kNStepsPerThread, kNThreadsPerWarp, kNWarpsPerBlock,
+            kNChunksPerSequence, grid, kNThreads, stream,
+            gates, output, outGrad, gateGradOut, valueGradOut,
+            batch_stride, dim_stride, reverse);
+    } else if (seqlen == 32768) {
+        constexpr int kNStepsPerThread = 4;
+        constexpr int kNWarpsPerBlock = 32;
+        constexpr int kNChunksPerSequence = 8;
+        int kNThreads = seqlen / kNStepsPerThread / kNChunksPerSequence;
+        DISPATCH_SCAN(weight_t, kNStepsPerThread, kNThreadsPerWarp, kNWarpsPerBlock,
+            kNChunksPerSequence, grid, kNThreads, stream,
+            gates, output, outGrad, gateGradOut, valueGradOut,
+            batch_stride, dim_stride, reverse);
+    } else if (seqlen == 65536) {
+        constexpr int kNStepsPerThread = 4;
+        constexpr int kNWarpsPerBlock = 32;
+        constexpr int kNChunksPerSequence = 16;
+        int kNThreads = seqlen / kNStepsPerThread / kNChunksPerSequence;
+        DISPATCH_SCAN(weight_t, kNStepsPerThread, kNThreadsPerWarp, kNWarpsPerBlock,
+            kNChunksPerSequence, grid, kNThreads, stream,
+            gates, output, outGrad, gateGradOut, valueGradOut,
+            batch_stride, dim_stride, reverse);
+    } else {
+        TORCH_CHECK(false && "seqlen must be a power of 2, >= 32, <= 65536");
+    }
+}
+
+at::Tensor
+warpscan_backward(const at::Tensor &gates, const at::Tensor &output, const at::Tensor &outGrad, const at::Tensor& gateGradOut, const at::Tensor& valueGradOut) {
+    TORCH_CHECK(gates.is_cuda());
+    TORCH_CHECK(output.is_cuda());
+    TORCH_CHECK(outGrad.is_cuda());
+    TORCH_CHECK(gateGradOut.is_contiguous());
+    TORCH_CHECK(valueGradOut.is_contiguous());
+    TORCH_CHECK(gates.scalar_type() == output.scalar_type());
+    TORCH_CHECK(gates.scalar_type() == outGrad.scalar_type());
+    TORCH_CHECK(gates.scalar_type() == gateGradOut.scalar_type());
+    TORCH_CHECK(gates.scalar_type() == valueGradOut.scalar_type());
+    TORCH_CHECK(gates.sizes() == output.sizes());
+    TORCH_CHECK(gates.sizes() == outGrad.sizes());
+    TORCH_CHECK(gates.sizes() == gateGradOut.sizes());
+    TORCH_CHECK(gates.sizes() == valueGradOut.sizes());
+
+    if (gates.scalar_type() == at::ScalarType::BFloat16) {
+        warpscan_grad<__nv_bfloat16, at::BFloat16>(gates, outputs, outGrad, gateGradOut, valueGradOut);
+    } else if (gates.scalar_type() == at::ScalarType::Half) {
+        warpscan_grad<__half, at::Half>(gates, outputs, outGrad, gateGradOut, valueGradOut);
+    } else if (gates.scalar_type() == at::ScalarType::Float) {
+        warpscan_grad<float, float>(gates, outputs, outGrad, gateGradOut, valueGradOut);
     } else {
         TORCH_CHECK(false && "Unsupported tensor dtype: expecting bfloat16, float16 or float32");
     }

--- a/accelerated_scan/warp.cuh
+++ b/accelerated_scan/warp.cuh
@@ -683,7 +683,7 @@ warpscan_grad(const at::Tensor &gates, const at::Tensor &output, const at::Tenso
     }
 }
 
-at::Tensor
+void
 warpscan_backward(const at::Tensor &gates, const at::Tensor &output, const at::Tensor &outGrad, const at::Tensor& gateGradOut, const at::Tensor& valueGradOut) {
     TORCH_CHECK(gates.is_cuda());
     TORCH_CHECK(output.is_cuda());
@@ -700,13 +700,12 @@ warpscan_backward(const at::Tensor &gates, const at::Tensor &output, const at::T
     TORCH_CHECK(gates.sizes() == valueGradOut.sizes());
 
     if (gates.scalar_type() == at::ScalarType::BFloat16) {
-        warpscan_grad<__nv_bfloat16, at::BFloat16>(gates, outputs, outGrad, gateGradOut, valueGradOut);
+        warpscan_grad<__nv_bfloat16, at::BFloat16>(gates, output, outGrad, gateGradOut, valueGradOut);
     } else if (gates.scalar_type() == at::ScalarType::Half) {
-        warpscan_grad<__half, at::Half>(gates, outputs, outGrad, gateGradOut, valueGradOut);
+        warpscan_grad<__half, at::Half>(gates, output, outGrad, gateGradOut, valueGradOut);
     } else if (gates.scalar_type() == at::ScalarType::Float) {
-        warpscan_grad<float, float>(gates, outputs, outGrad, gateGradOut, valueGradOut);
+        warpscan_grad<float, float>(gates, output, outGrad, gateGradOut, valueGradOut);
     } else {
         TORCH_CHECK(false && "Unsupported tensor dtype: expecting bfloat16, float16 or float32");
     }
-    return out;
 }

--- a/accelerated_scan/warp.cuh
+++ b/accelerated_scan/warp.cuh
@@ -347,7 +347,7 @@ warpscan_forward(const at::Tensor &gates, const at::Tensor &tokens, const at::Te
 }
 
 template <typename Tuple, int offset>
-Tuple load_shifted_tuple(const Tuple* ptr, int index, int limit) {
+__device__ Tuple load_shifted_tuple(const Tuple* ptr, int index, int limit) {
     using weight_t = typename Tuple::Type;
 
     const weight_t* rawPtr = reinterpret_cast<const weight_t *>(ptr);

--- a/accelerated_scan/warp.cuh
+++ b/accelerated_scan/warp.cuh
@@ -353,8 +353,8 @@ Tuple load_shifted_tuple(const Tuple* ptr, int index, int limit) {
     const weight_t* rawPtr = reinterpret_cast<const weight_t *>(ptr);
     Tuple x;
     for (int i = 0; i < Tuple::Size; i++) {
-        const int offset = index*4 + i + offset;
-        if (offset >= 0 && offset < limit*4) {
+        const int idx = index * Tuple::Size + i + offset;
+        if (idx >= 0 && idx < limit * Tuple::Size) {
             x.data[i] = rawPtr[offset];
         }
     }
@@ -502,9 +502,7 @@ __global__ void scan_grad(
                 accGate.data[i] = warpLastGate[warpId-1] * accGate.data[i];
             }
         }
-        if (reverse) {
-            accToken.reverse();
-        }
+        accToken.reverse();
         valueGradOut[tupleOffset] = accToken;
 
         Tuple gateGrad = load_shifted_tuple<Tuple, -1>(output, tupleOffset, limit);

--- a/accelerated_scan/warp.cuh
+++ b/accelerated_scan/warp.cuh
@@ -357,7 +357,7 @@ __device__ Tuple load_shifted_tuple(const Tuple* ptr, int index, int limit) {
         if (idx >= 0 && idx < limit * Tuple::Size) {
             x.data[i] = rawPtr[offset];
         } else {
-            x.data[i] = 0;
+            x.data[i] = 0.0;
         }
     }
 

--- a/accelerated_scan/warp.cuh
+++ b/accelerated_scan/warp.cuh
@@ -391,8 +391,8 @@ __global__ void scan_grad(
     const weight_t kEmptyToken = 0.0;
 
     // Limits for loading shifted tuples.
-    const int minIdx = blockDim.x * kNChunksPerSequence * blockIdx.x;
-    const int maxIdx = blockDim.x * kNChunksPerSequence * (blockIdx.x + 1);
+    const int minIdx = seqoffset / Tuple::Size;
+    const int maxIdx = minIdx + blockDim.x * kNChunksPerSequence;
 
     for (int chunk = 0; chunk < kNChunksPerSequence; chunk++) {
         const int offset = seqoffset + (kNChunksPerSequence - 1 - chunk) * chunklen;

--- a/accelerated_scan/warp.cuh
+++ b/accelerated_scan/warp.cuh
@@ -585,7 +585,7 @@ warpscan_grad(const at::Tensor &gates, const at::Tensor &output, const at::Tenso
         constexpr int kNWarpsPerBlock = 1;
         constexpr int kNChunksPerSequence = 1;
         int kNThreads = seqlen / kNStepsPerThread / kNChunksPerSequence;
-        DISPATCH_SCAN(weight_t, kNStepsPerThread, kNThreadsPerWarp, kNWarpsPerBlock,
+        DISPATCH_SCAN_GRAD(weight_t, kNStepsPerThread, kNThreadsPerWarp, kNWarpsPerBlock,
             kNChunksPerSequence, grid, kNThreads, stream,
             gates, output, outGrad, gateGradOut, valueGradOut,
             batch_stride, dim_stride, reverse);
@@ -594,7 +594,7 @@ warpscan_grad(const at::Tensor &gates, const at::Tensor &output, const at::Tenso
         constexpr int kNWarpsPerBlock = 4;
         int kNThreads = seqlen / kNStepsPerThread;
         constexpr int kNChunksPerSequence = 1;
-        DISPATCH_SCAN(weight_t, kNStepsPerThread, kNThreadsPerWarp, kNWarpsPerBlock,
+        DISPATCH_SCAN_GRAD(weight_t, kNStepsPerThread, kNThreadsPerWarp, kNWarpsPerBlock,
             kNChunksPerSequence, grid, kNThreads, stream,
             gates, output, outGrad, gateGradOut, valueGradOut,
             batch_stride, dim_stride, reverse);
@@ -603,7 +603,7 @@ warpscan_grad(const at::Tensor &gates, const at::Tensor &output, const at::Tenso
         constexpr int kNWarpsPerBlock = 8;
         int kNThreads = seqlen / kNStepsPerThread;
         constexpr int kNChunksPerSequence = 1;
-        DISPATCH_SCAN(weight_t, kNStepsPerThread, kNThreadsPerWarp, kNWarpsPerBlock,
+        DISPATCH_SCAN_GRAD(weight_t, kNStepsPerThread, kNThreadsPerWarp, kNWarpsPerBlock,
             kNChunksPerSequence, grid, kNThreads, stream,
             gates, output, outGrad, gateGradOut, valueGradOut,
             batch_stride, dim_stride, reverse);
@@ -612,7 +612,7 @@ warpscan_grad(const at::Tensor &gates, const at::Tensor &output, const at::Tenso
         constexpr int kNWarpsPerBlock = 16;
         int kNThreads = seqlen / kNStepsPerThread;
         constexpr int kNChunksPerSequence = 1;
-        DISPATCH_SCAN(weight_t, kNStepsPerThread, kNThreadsPerWarp, kNWarpsPerBlock,
+        DISPATCH_SCAN_GRAD(weight_t, kNStepsPerThread, kNThreadsPerWarp, kNWarpsPerBlock,
             kNChunksPerSequence, grid, kNThreads, stream,
             gates, output, outGrad, gateGradOut, valueGradOut,
             batch_stride, dim_stride, reverse);
@@ -621,7 +621,7 @@ warpscan_grad(const at::Tensor &gates, const at::Tensor &output, const at::Tenso
         constexpr int kNWarpsPerBlock = 16;
         int kNThreads = seqlen / kNStepsPerThread;
         constexpr int kNChunksPerSequence = 1;
-        DISPATCH_SCAN(weight_t, kNStepsPerThread, kNThreadsPerWarp, kNWarpsPerBlock,
+        DISPATCH_SCAN_GRAD(weight_t, kNStepsPerThread, kNThreadsPerWarp, kNWarpsPerBlock,
             kNChunksPerSequence, grid, kNThreads, stream,
             gates, output, outGrad, gateGradOut, valueGradOut,
             batch_stride, dim_stride, reverse);
@@ -630,7 +630,7 @@ warpscan_grad(const at::Tensor &gates, const at::Tensor &output, const at::Tenso
         constexpr int kNWarpsPerBlock = 32;
         int kNThreads = seqlen / kNStepsPerThread;
         constexpr int kNChunksPerSequence = 1;
-        DISPATCH_SCAN(weight_t, kNStepsPerThread, kNThreadsPerWarp, kNWarpsPerBlock,
+        DISPATCH_SCAN_GRAD(weight_t, kNStepsPerThread, kNThreadsPerWarp, kNWarpsPerBlock,
             kNChunksPerSequence, grid, kNThreads, stream,
             gates, output, outGrad, gateGradOut, valueGradOut,
             batch_stride, dim_stride, reverse);
@@ -639,7 +639,7 @@ warpscan_grad(const at::Tensor &gates, const at::Tensor &output, const at::Tenso
         constexpr int kNWarpsPerBlock = 32;
         int kNThreads = seqlen / kNStepsPerThread;
         constexpr int kNChunksPerSequence = 1;
-        DISPATCH_SCAN(weight_t, kNStepsPerThread, kNThreadsPerWarp, kNWarpsPerBlock,
+        DISPATCH_SCAN_GRAD(weight_t, kNStepsPerThread, kNThreadsPerWarp, kNWarpsPerBlock,
             kNChunksPerSequence, grid, kNThreads, stream,
             gates, output, outGrad, gateGradOut, valueGradOut,
             batch_stride, dim_stride, reverse);
@@ -648,7 +648,7 @@ warpscan_grad(const at::Tensor &gates, const at::Tensor &output, const at::Tenso
         constexpr int kNWarpsPerBlock = 32;
         constexpr int kNChunksPerSequence = 2;
         int kNThreads = seqlen / kNStepsPerThread / kNChunksPerSequence;
-        DISPATCH_SCAN(weight_t, kNStepsPerThread, kNThreadsPerWarp, kNWarpsPerBlock,
+        DISPATCH_SCAN_GRAD(weight_t, kNStepsPerThread, kNThreadsPerWarp, kNWarpsPerBlock,
             kNChunksPerSequence, grid, kNThreads, stream,
             gates, output, outGrad, gateGradOut, valueGradOut,
             batch_stride, dim_stride, reverse);
@@ -657,7 +657,7 @@ warpscan_grad(const at::Tensor &gates, const at::Tensor &output, const at::Tenso
         constexpr int kNWarpsPerBlock = 32;
         constexpr int kNChunksPerSequence = 4;
         int kNThreads = seqlen / kNStepsPerThread / kNChunksPerSequence;
-        DISPATCH_SCAN(weight_t, kNStepsPerThread, kNThreadsPerWarp, kNWarpsPerBlock,
+        DISPATCH_SCAN_GRAD(weight_t, kNStepsPerThread, kNThreadsPerWarp, kNWarpsPerBlock,
             kNChunksPerSequence, grid, kNThreads, stream,
             gates, output, outGrad, gateGradOut, valueGradOut,
             batch_stride, dim_stride, reverse);
@@ -666,7 +666,7 @@ warpscan_grad(const at::Tensor &gates, const at::Tensor &output, const at::Tenso
         constexpr int kNWarpsPerBlock = 32;
         constexpr int kNChunksPerSequence = 8;
         int kNThreads = seqlen / kNStepsPerThread / kNChunksPerSequence;
-        DISPATCH_SCAN(weight_t, kNStepsPerThread, kNThreadsPerWarp, kNWarpsPerBlock,
+        DISPATCH_SCAN_GRAD(weight_t, kNStepsPerThread, kNThreadsPerWarp, kNWarpsPerBlock,
             kNChunksPerSequence, grid, kNThreads, stream,
             gates, output, outGrad, gateGradOut, valueGradOut,
             batch_stride, dim_stride, reverse);
@@ -675,7 +675,7 @@ warpscan_grad(const at::Tensor &gates, const at::Tensor &output, const at::Tenso
         constexpr int kNWarpsPerBlock = 32;
         constexpr int kNChunksPerSequence = 16;
         int kNThreads = seqlen / kNStepsPerThread / kNChunksPerSequence;
-        DISPATCH_SCAN(weight_t, kNStepsPerThread, kNThreadsPerWarp, kNWarpsPerBlock,
+        DISPATCH_SCAN_GRAD(weight_t, kNStepsPerThread, kNThreadsPerWarp, kNWarpsPerBlock,
             kNChunksPerSequence, grid, kNThreads, stream,
             gates, output, outGrad, gateGradOut, valueGradOut,
             batch_stride, dim_stride, reverse);

--- a/accelerated_scan/warp.cuh
+++ b/accelerated_scan/warp.cuh
@@ -28,11 +28,33 @@ template<typename T, int N>
 class alignas(16) AlignedTuple : public UnalignedTuple<T, N> {
 };
 
-template <typename Tuple, int kNThreadsPerWarp, int kNWarpsPerBlock, int kNChunksPerSequence>
+template <typename Tuple, int offset>
+__device__ Tuple load_shifted_tuple(const Tuple* ptr, int index, int minIdx, int maxIdx) {
+    using weight_t = typename Tuple::Type;
+
+    const weight_t* rawPtr = reinterpret_cast<const weight_t *>(ptr);
+    Tuple x;
+    for (int i = 0; i < Tuple::Size; i++) {
+        const int idx = index * Tuple::Size + i + offset;
+        if (idx >= minIdx * Tuple::Size && idx < maxIdx * Tuple::Size) {
+            x.data[i] = rawPtr[idx];
+        } else {
+            x.data[i] = 0.0;
+        }
+    }
+
+    return x;
+}
+
+template <typename Tuple, int kNThreadsPerWarp, int kNWarpsPerBlock, int kNChunksPerSequence, bool backward>
 __global__ void scan(
     const Tuple* gates,
     const Tuple* tokens,
     Tuple* result,
+    // Only passed if backward is True.
+    const Tuple* output,
+    Tuple* gateGradOut,
+    // Shape information
     const int batch_stride,
     const int dim_stride,
     const bool reverse
@@ -53,6 +75,10 @@ __global__ void scan(
     const weight_t kEmptyGate = 1.0;
     const weight_t kEmptyToken = 0.0;
 
+    // Limits for loading shifted tuples during backward pass.
+    const int minIdx = seqoffset / Tuple::Size;
+    const int maxIdx = minIdx + blockDim.x * kNChunksPerSequence;
+
     //
     // Read from global memory.
     // Scan sequentially in thread registers (level 0).
@@ -66,7 +92,12 @@ __global__ void scan(
             __syncthreads();
         }
 
-        Tuple loadedGate = gates[tupleOffset];
+        Tuple loadedGate;
+        if (backward) {
+            loadedGate = load_shifted_tuple<Tuple, 1>(gates, tupleOffset, minIdx, maxIdx);
+        } else {
+            loadedGate = gates[tupleOffset];
+        }
         Tuple loadedToken = tokens[tupleOffset];
         if (reverse) {
             loadedGate.reverse();
@@ -176,6 +207,14 @@ __global__ void scan(
         }
         result[tupleOffset] = accToken;
 
+        if (backward) {
+            Tuple gateGrad = load_shifted_tuple<Tuple, -1>(output, tupleOffset, minIdx, maxIdx);
+            for (int i = 0; i < Tuple::Size; i++) {
+                gateGrad.data[i] = gateGrad.data[i] * accToken.data[i];
+            }
+            gateGradOut[tupleOffset] = gateGrad;
+        }
+
         if (laneId == kWarpLast && warpId == kBlockLast) {
             chunkAccGate = accGate.data[kThreadLast];
             chunkAccToken = accToken.data[kThreadLast];
@@ -183,31 +222,67 @@ __global__ void scan(
     }
 }
 
-#define DISPATCH_SCAN(weight_t, kNStepsPerThread, kNThreadsPerWarp, kNWarpsPerBlock, kNChunksPerSequence, grid, kNThreads, stream, gates, tokens, out, batch_stride, dim_stride, reverse) \
+#define DISPATCH_SCAN(weight_t, kNStepsPerThread, kNThreadsPerWarp, kNWarpsPerBlock, kNChunksPerSequence, grid, kNThreads, stream, gates, tokens, out, output, gateGradOut, batch_stride, dim_stride, reverse) \
     using AlignedT = AlignedTuple<weight_t, kNStepsPerThread>; \
     using UnalignedT = UnalignedTuple<weight_t, kNStepsPerThread>; \
-    if (kNStepsPerThread == 4 && \
-        ((long)gates.data_ptr()) % 16 == 0 && \
-        ((long)tokens.data_ptr()) % 16 == 0 && \
-        ((long)out.data_ptr()) % 16 == 0) { \
-        scan<AlignedT, kNThreadsPerWarp, kNWarpsPerBlock, kNChunksPerSequence><<<grid, kNThreads, kNWarpsPerBlock * sizeof(weight_t) * 2, stream>>>( \
-                reinterpret_cast<const AlignedT *>(gates.data_ptr<torch_weight_t>()), \
-                reinterpret_cast<const AlignedT *>(tokens.data_ptr<torch_weight_t>()), \
-                reinterpret_cast<AlignedT *>(out.data_ptr<torch_weight_t>()), \
-                batch_stride, dim_stride, reverse \
-            ); \
+    if (!output) { \
+        if (kNStepsPerThread == 4 && \
+            ((long)gates.data_ptr()) % 16 == 0 && \
+            ((long)tokens.data_ptr()) % 16 == 0 && \
+            ((long)out.data_ptr()) % 16 == 0) { \
+            scan<AlignedT, kNThreadsPerWarp, kNWarpsPerBlock, kNChunksPerSequence, false><<<grid, kNThreads, kNWarpsPerBlock * sizeof(weight_t) * 2, stream>>>( \
+                    reinterpret_cast<const AlignedT *>(gates.data_ptr<torch_weight_t>()), \
+                    reinterpret_cast<const AlignedT *>(tokens.data_ptr<torch_weight_t>()), \
+                    reinterpret_cast<AlignedT *>(out.data_ptr<torch_weight_t>()), \
+                    nullptr, nullptr, \
+                    batch_stride, dim_stride, reverse \
+                ); \
+        } else { \
+            scan<UnalignedT, kNThreadsPerWarp, kNWarpsPerBlock, kNChunksPerSequence, false><<<grid, kNThreads, kNWarpsPerBlock * sizeof(weight_t) * 2, stream>>>( \
+                    reinterpret_cast<const UnalignedT*>(gates.data_ptr<torch_weight_t>()), \
+                    reinterpret_cast<const UnalignedT*>(tokens.data_ptr<torch_weight_t>()), \
+                    reinterpret_cast<UnalignedT *>(out.data_ptr<torch_weight_t>()), \
+                    nullptr, nullptr, \
+                    batch_stride, dim_stride, reverse \
+                ); \
+        } \
     } else { \
-        scan<UnalignedT, kNThreadsPerWarp, kNWarpsPerBlock, kNChunksPerSequence><<<grid, kNThreads, kNWarpsPerBlock * sizeof(weight_t) * 2, stream>>>( \
-                reinterpret_cast<const UnalignedT*>(gates.data_ptr<torch_weight_t>()), \
-                reinterpret_cast<const UnalignedT*>(tokens.data_ptr<torch_weight_t>()), \
-                reinterpret_cast<UnalignedT *>(out.data_ptr<torch_weight_t>()), \
-                batch_stride, dim_stride, reverse \
-            ); \
+        if (kNStepsPerThread == 4 && \
+            ((long)gates.data_ptr()) % 16 == 0 && \
+            ((long)tokens.data_ptr()) % 16 == 0 && \
+            ((long)out.data_ptr()) % 16 == 0 && \
+            ((long)output) % 16 == 0 && \
+            ((long)gateGradOut) % 16 == 0) { \
+            scan<AlignedT, kNThreadsPerWarp, kNWarpsPerBlock, kNChunksPerSequence, true><<<grid, kNThreads, kNWarpsPerBlock * sizeof(weight_t) * 2, stream>>>( \
+                    reinterpret_cast<const AlignedT *>(gates.data_ptr<torch_weight_t>()), \
+                    reinterpret_cast<const AlignedT *>(tokens.data_ptr<torch_weight_t>()), \
+                    reinterpret_cast<AlignedT *>(out.data_ptr<torch_weight_t>()), \
+                    reinterpret_cast<const AlignedT *>(output), \
+                    reinterpret_cast<AlignedT *>(gateGradOut), \
+                    batch_stride, dim_stride, reverse \
+                ); \
+        } else { \
+            scan<UnalignedT, kNThreadsPerWarp, kNWarpsPerBlock, kNChunksPerSequence, true><<<grid, kNThreads, kNWarpsPerBlock * sizeof(weight_t) * 2, stream>>>( \
+                    reinterpret_cast<const UnalignedT*>(gates.data_ptr<torch_weight_t>()), \
+                    reinterpret_cast<const UnalignedT*>(tokens.data_ptr<torch_weight_t>()), \
+                    reinterpret_cast<UnalignedT *>(out.data_ptr<torch_weight_t>()), \
+                    reinterpret_cast<const UnalignedT *>(output), \
+                    reinterpret_cast<UnalignedT *>(gateGradOut), \
+                    batch_stride, dim_stride, reverse \
+                ); \
+        } \
     }
 
 template <typename weight_t, typename torch_weight_t>
 void
-warpscan(const at::Tensor &gates, const at::Tensor &tokens, const at::Tensor &out, const bool reverse) {
+warpscan(
+    const at::Tensor &gates,
+    const at::Tensor &tokens,
+    const at::Tensor &out,
+    const void *output,
+    void *gateGradOut,
+    const bool reverse
+) {
     const auto strides = tokens.strides();
     const int batch_stride = strides[0];
     const int dim_stride = strides[1];
@@ -229,7 +304,7 @@ warpscan(const at::Tensor &gates, const at::Tensor &tokens, const at::Tensor &ou
         int kNThreads = seqlen / kNStepsPerThread;
         constexpr int kNChunksPerSequence = 1;
         DISPATCH_SCAN(weight_t, kNStepsPerThread, kNThreadsPerWarp, kNWarpsPerBlock,
-            kNChunksPerSequence, grid, kNThreads, stream, gates, tokens, out,
+            kNChunksPerSequence, grid, kNThreads, stream, gates, tokens, out, output, gateGradOut,
             batch_stride, dim_stride, reverse);
     } else if (seqlen == 64) {
         constexpr int kNStepsPerThread = 2;
@@ -237,7 +312,7 @@ warpscan(const at::Tensor &gates, const at::Tensor &tokens, const at::Tensor &ou
         constexpr int kNChunksPerSequence = 1;
         int kNThreads = seqlen / kNStepsPerThread / kNChunksPerSequence;
         DISPATCH_SCAN(weight_t, kNStepsPerThread, kNThreadsPerWarp, kNWarpsPerBlock,
-            kNChunksPerSequence, grid, kNThreads, stream, gates, tokens, out,
+            kNChunksPerSequence, grid, kNThreads, stream, gates, tokens, out, output, gateGradOut,
             batch_stride, dim_stride, reverse);
     } else if (seqlen == 128) {
         constexpr int kNStepsPerThread = 1;
@@ -245,7 +320,7 @@ warpscan(const at::Tensor &gates, const at::Tensor &tokens, const at::Tensor &ou
         int kNThreads = seqlen / kNStepsPerThread;
         constexpr int kNChunksPerSequence = 1;
         DISPATCH_SCAN(weight_t, kNStepsPerThread, kNThreadsPerWarp, kNWarpsPerBlock,
-            kNChunksPerSequence, grid, kNThreads, stream, gates, tokens, out,
+            kNChunksPerSequence, grid, kNThreads, stream, gates, tokens, out, output, gateGradOut,
             batch_stride, dim_stride, reverse);
     } else if (seqlen == 256) {
         constexpr int kNStepsPerThread = 1;
@@ -253,7 +328,7 @@ warpscan(const at::Tensor &gates, const at::Tensor &tokens, const at::Tensor &ou
         int kNThreads = seqlen / kNStepsPerThread;
         constexpr int kNChunksPerSequence = 1;
         DISPATCH_SCAN(weight_t, kNStepsPerThread, kNThreadsPerWarp, kNWarpsPerBlock,
-            kNChunksPerSequence, grid, kNThreads, stream, gates, tokens, out,
+            kNChunksPerSequence, grid, kNThreads, stream, gates, tokens, out, output, gateGradOut,
             batch_stride, dim_stride, reverse);
     } else if (seqlen == 512) {
         constexpr int kNStepsPerThread = 1;
@@ -261,7 +336,7 @@ warpscan(const at::Tensor &gates, const at::Tensor &tokens, const at::Tensor &ou
         int kNThreads = seqlen / kNStepsPerThread;
         constexpr int kNChunksPerSequence = 1;
         DISPATCH_SCAN(weight_t, kNStepsPerThread, kNThreadsPerWarp, kNWarpsPerBlock,
-            kNChunksPerSequence, grid, kNThreads, stream, gates, tokens, out,
+            kNChunksPerSequence, grid, kNThreads, stream, gates, tokens, out, output, gateGradOut,
             batch_stride, dim_stride, reverse);
     } else if (seqlen == 1024) {
         constexpr int kNStepsPerThread = 2;
@@ -269,7 +344,7 @@ warpscan(const at::Tensor &gates, const at::Tensor &tokens, const at::Tensor &ou
         int kNThreads = seqlen / kNStepsPerThread;
         constexpr int kNChunksPerSequence = 1;
         DISPATCH_SCAN(weight_t, kNStepsPerThread, kNThreadsPerWarp, kNWarpsPerBlock,
-            kNChunksPerSequence, grid, kNThreads, stream, gates, tokens, out,
+            kNChunksPerSequence, grid, kNThreads, stream, gates, tokens, out, output, gateGradOut,
             batch_stride, dim_stride, reverse);
     } else if (seqlen == 2048) {
         constexpr int kNStepsPerThread = 2;
@@ -277,7 +352,7 @@ warpscan(const at::Tensor &gates, const at::Tensor &tokens, const at::Tensor &ou
         int kNThreads = seqlen / kNStepsPerThread;
         constexpr int kNChunksPerSequence = 1;
         DISPATCH_SCAN(weight_t, kNStepsPerThread, kNThreadsPerWarp, kNWarpsPerBlock,
-            kNChunksPerSequence, grid, kNThreads, stream, gates, tokens, out,
+            kNChunksPerSequence, grid, kNThreads, stream, gates, tokens, out, output, gateGradOut,
             batch_stride, dim_stride, reverse);
     } else if (seqlen == 4096) {
         constexpr int kNStepsPerThread = 4;
@@ -285,7 +360,7 @@ warpscan(const at::Tensor &gates, const at::Tensor &tokens, const at::Tensor &ou
         int kNThreads = seqlen / kNStepsPerThread;
         constexpr int kNChunksPerSequence = 1;
         DISPATCH_SCAN(weight_t, kNStepsPerThread, kNThreadsPerWarp, kNWarpsPerBlock,
-            kNChunksPerSequence, grid, kNThreads, stream, gates, tokens, out,
+            kNChunksPerSequence, grid, kNThreads, stream, gates, tokens, out, output, gateGradOut,
             batch_stride, dim_stride, reverse);
     } else if (seqlen == 8192) {
         constexpr int kNStepsPerThread = 4;
@@ -293,7 +368,7 @@ warpscan(const at::Tensor &gates, const at::Tensor &tokens, const at::Tensor &ou
         constexpr int kNChunksPerSequence = 2;
         int kNThreads = seqlen / kNStepsPerThread / kNChunksPerSequence;
         DISPATCH_SCAN(weight_t, kNStepsPerThread, kNThreadsPerWarp, kNWarpsPerBlock,
-            kNChunksPerSequence, grid, kNThreads, stream, gates, tokens, out,
+            kNChunksPerSequence, grid, kNThreads, stream, gates, tokens, out, output, gateGradOut,
             batch_stride, dim_stride, reverse);
     } else if (seqlen == 16384) {
         constexpr int kNStepsPerThread = 4;
@@ -301,7 +376,7 @@ warpscan(const at::Tensor &gates, const at::Tensor &tokens, const at::Tensor &ou
         constexpr int kNChunksPerSequence = 4;
         int kNThreads = seqlen / kNStepsPerThread / kNChunksPerSequence;
         DISPATCH_SCAN(weight_t, kNStepsPerThread, kNThreadsPerWarp, kNWarpsPerBlock,
-            kNChunksPerSequence, grid, kNThreads, stream, gates, tokens, out,
+            kNChunksPerSequence, grid, kNThreads, stream, gates, tokens, out, output, gateGradOut,
             batch_stride, dim_stride, reverse);
     } else if (seqlen == 32768) {
         constexpr int kNStepsPerThread = 4;
@@ -309,7 +384,7 @@ warpscan(const at::Tensor &gates, const at::Tensor &tokens, const at::Tensor &ou
         constexpr int kNChunksPerSequence = 8;
         int kNThreads = seqlen / kNStepsPerThread / kNChunksPerSequence;
         DISPATCH_SCAN(weight_t, kNStepsPerThread, kNThreadsPerWarp, kNWarpsPerBlock,
-            kNChunksPerSequence, grid, kNThreads, stream, gates, tokens, out,
+            kNChunksPerSequence, grid, kNThreads, stream, gates, tokens, out, output, gateGradOut,
             batch_stride, dim_stride, reverse);
     } else if (seqlen == 65536) {
         constexpr int kNStepsPerThread = 4;
@@ -317,12 +392,23 @@ warpscan(const at::Tensor &gates, const at::Tensor &tokens, const at::Tensor &ou
         constexpr int kNChunksPerSequence = 16;
         int kNThreads = seqlen / kNStepsPerThread / kNChunksPerSequence;
         DISPATCH_SCAN(weight_t, kNStepsPerThread, kNThreadsPerWarp, kNWarpsPerBlock,
-            kNChunksPerSequence, grid, kNThreads, stream, gates, tokens, out,
+            kNChunksPerSequence, grid, kNThreads, stream, gates, tokens, out, output, gateGradOut,
             batch_stride, dim_stride, reverse);
     } else {
         TORCH_CHECK(false && "seqlen must be a power of 2, >= 32, <= 65536");
     }
 }
+
+#define DISPATCH_WARPSCAN(gates, ...) \
+    if (gates.scalar_type() == at::ScalarType::BFloat16) { \
+        warpscan<__nv_bfloat16, at::BFloat16>(gates, __VA_ARGS__); \
+    } else if (gates.scalar_type() == at::ScalarType::Half) { \
+        warpscan<__half, at::Half>(gates, __VA_ARGS__); \
+    } else if (gates.scalar_type() == at::ScalarType::Float) { \
+        warpscan<float, float>(gates, __VA_ARGS__); \
+    } else { \
+        TORCH_CHECK(false && "Unsupported tensor dtype: expecting bfloat16, float16 or float32"); \
+    }
 
 at::Tensor
 warpscan_forward(const at::Tensor &gates, const at::Tensor &tokens, const at::Tensor &out, const bool reverse) {
@@ -330,360 +416,11 @@ warpscan_forward(const at::Tensor &gates, const at::Tensor &tokens, const at::Te
     TORCH_CHECK(gates.is_cuda());
     TORCH_CHECK(tokens.is_contiguous());
     TORCH_CHECK(gates.is_contiguous());
+    TORCH_CHECK(tokens.scalar_type() == gates.scalar_type());
+    TORCH_CHECK(tokens.scalar_type() == out.scalar_type());
 
-    if (tokens.scalar_type() == at::ScalarType::BFloat16) {
-        TORCH_CHECK(gates.scalar_type() == at::ScalarType::BFloat16);
-        warpscan<__nv_bfloat16, at::BFloat16>(gates, tokens, out, reverse);
-    } else if (tokens.scalar_type() == at::ScalarType::Half) {
-        TORCH_CHECK(gates.scalar_type() == at::ScalarType::Half);
-        warpscan<__half, at::Half>(gates, tokens, out, reverse);
-    } else if (tokens.scalar_type() == at::ScalarType::Float) {
-        TORCH_CHECK(gates.scalar_type() == at::ScalarType::Float);
-        warpscan<float, float>(gates, tokens, out, reverse);
-    } else {
-        TORCH_CHECK(false && "Unsupported tensor dtype: expecting bfloat16, float16 or float32");
-    }
+    DISPATCH_WARPSCAN(gates, tokens, out, nullptr, nullptr, reverse);
     return out;
-}
-
-template <typename Tuple, int offset>
-__device__ Tuple load_shifted_tuple(const Tuple* ptr, int index, int minIdx, int maxIdx) {
-    using weight_t = typename Tuple::Type;
-
-    const weight_t* rawPtr = reinterpret_cast<const weight_t *>(ptr);
-    Tuple x;
-    for (int i = 0; i < Tuple::Size; i++) {
-        const int idx = index * Tuple::Size + i + offset;
-        if (idx >= minIdx * Tuple::Size && idx < maxIdx * Tuple::Size) {
-            x.data[i] = rawPtr[idx];
-        } else {
-            x.data[i] = 0.0;
-        }
-    }
-
-    return x;
-}
-
-template <typename Tuple, int kNThreadsPerWarp, int kNWarpsPerBlock, int kNChunksPerSequence>
-__global__ void scan_grad(
-    const Tuple* gates,
-    const Tuple* output,
-    const Tuple* outGrad,
-    Tuple* gateGradOut,
-    Tuple* tokenGradOut,
-    const int batch_stride,
-    const int dim_stride
-) {
-    using weight_t = typename Tuple::Type;
-
-    __shared__ weight_t warpLastGate[kNWarpsPerBlock];
-    __shared__ weight_t warpLastToken[kNWarpsPerBlock];
-    __shared__ weight_t chunkAccGate, chunkAccToken;
-
-    const int seqoffset = blockIdx.x * batch_stride + blockIdx.y * dim_stride;
-    const int warpId = threadIdx.x / kNThreadsPerWarp;
-    const int laneId = threadIdx.x % kNThreadsPerWarp;
-    const int chunklen = blockDim.x * Tuple::Size;
-    constexpr int kBlockLast = kNWarpsPerBlock - 1;
-    constexpr int kWarpLast = kNThreadsPerWarp - 1;
-    constexpr int kThreadLast = Tuple::Size - 1;
-    const weight_t kEmptyGate = 1.0;
-    const weight_t kEmptyToken = 0.0;
-
-    // Limits for loading shifted tuples.
-    const int minIdx = seqoffset / Tuple::Size;
-    const int maxIdx = minIdx + blockDim.x * kNChunksPerSequence;
-
-    for (int chunk = 0; chunk < kNChunksPerSequence; chunk++) {
-        const int offset = seqoffset + (kNChunksPerSequence - 1 - chunk) * chunklen;
-        const int tupleOffset = (offset + (chunklen - ((threadIdx.x + 1) * Tuple::Size))) / Tuple::Size;
-
-        if (chunk) {
-            __syncthreads();
-        }
-
-        // Load from global memory.
-        Tuple loadedGate = load_shifted_tuple<Tuple, 1>(gates, tupleOffset, minIdx, maxIdx);
-        Tuple loadedToken = outGrad[tupleOffset];
-        loadedGate.reverse();
-        loadedToken.reverse();
-
-        Tuple accGate;
-        Tuple accToken;
-
-        // Scan within the current thread.
-        #pragma unroll
-        for (int i = 0; i < Tuple::Size; ++i) {
-            weight_t gate = loadedGate.data[i];
-            weight_t token = loadedToken.data[i];
-            if (i == 0) {
-                if (chunk == 0) {
-                    accGate.data[0] = threadIdx.x == 0 ? kEmptyGate : gate;
-                    accToken.data[0] = token;
-                } else {
-                    if (threadIdx.x == 0) {
-                        // Add the last element of the previous chunk to the first element of the current chunk.
-                        accGate.data[0] = chunkAccGate * gate;
-                        accToken.data[0] = chunkAccToken * gate + token;
-                    } else {
-                        accGate.data[0] = gate;
-                        accToken.data[0] = token;
-                    }
-                }
-            } else {
-                accGate.data[i] = accGate.data[i - 1] * gate;
-                accToken.data[i] = accToken.data[i - 1] * gate + token;
-            }
-        }
-
-        //
-        // Scan threads in a warp using shuffling (level 1).
-        //
-
-        #pragma unroll
-        for (int delta = 1; delta < kNThreadsPerWarp; delta *= 2) {
-            weight_t prev_gate = __shfl_up_sync(0xffffffff, accGate.data[kThreadLast], delta);
-            weight_t prev_token = __shfl_up_sync(0xffffffff, accToken.data[kThreadLast], delta);
-
-            if (laneId >= delta) {
-                #pragma unroll
-                for (int i = 0; i < Tuple::Size; ++i) {
-                    accToken.data[i] = prev_token * accGate.data[i] + accToken.data[i];
-                    accGate.data[i] = prev_gate * accGate.data[i];
-                }
-            }
-        }
-
-        __syncwarp();
-
-        //
-        // Store the last element of each warp in shared memory.
-        //
-
-        if (laneId == kWarpLast) {
-            warpLastGate[warpId] = accGate.data[kThreadLast];
-            warpLastToken[warpId] = accToken.data[kThreadLast];
-        }
-
-        __syncthreads();
-
-        //
-        // Leading warp scans every warp in a block (level 2).
-        //
-
-        if (warpId == 0) {
-            weight_t warpAccGate, warpAccToken;
-            warpAccGate = (laneId < kNWarpsPerBlock) ? warpLastGate[laneId] : kEmptyGate;
-            warpAccToken = (laneId < kNWarpsPerBlock) ? warpLastToken[laneId] : kEmptyToken;
-
-            #pragma unroll
-            for (int delta = 1; delta < warpSize; delta *= 2) {
-                weight_t prev_gate = __shfl_up_sync(0xffffffff, warpAccGate, delta);
-                weight_t prev_token = __shfl_up_sync(0xffffffff, warpAccToken, delta);
-
-                if (laneId >= delta) {
-                    warpAccToken = prev_token * warpAccGate + warpAccToken;
-                    warpAccGate = prev_gate * warpAccGate;
-                }
-            }
-
-            if (laneId < kNWarpsPerBlock) {
-                warpLastGate[laneId] = warpAccGate;
-                warpLastToken[laneId] = warpAccToken;
-            }
-        }
-
-        __syncthreads();
-
-        //
-        // Add the last element of the previous warp to each element of the current warp (level 0).
-        // Store to global memory.
-        //
-
-        #pragma unroll
-        for (int i = 0; i < Tuple::Size; ++i) {
-            if (warpId > 0) {
-                accToken.data[i] = warpLastToken[warpId-1] * accGate.data[i] + accToken.data[i];
-                accGate.data[i] = warpLastGate[warpId-1] * accGate.data[i];
-            }
-        }
-        accToken.reverse();
-        tokenGradOut[tupleOffset] = accToken;
-
-        Tuple gateGrad = load_shifted_tuple<Tuple, -1>(output, tupleOffset, minIdx, maxIdx);
-        for (int i = 0; i < Tuple::Size; i++) {
-            gateGrad.data[i] = gateGrad.data[i] * accToken.data[i];
-        }
-        gateGradOut[tupleOffset] = gateGrad;
-
-        if (laneId == kWarpLast && warpId == kBlockLast) {
-            chunkAccGate = accGate.data[kThreadLast];
-            chunkAccToken = accToken.data[kThreadLast];
-        }
-    }
-}
-
-#define DISPATCH_SCAN_GRAD(weight_t, kNStepsPerThread, kNThreadsPerWarp, kNWarpsPerBlock, kNChunksPerSequence, grid, kNThreads, stream, gates, output, outGrad, gateGradOut, tokenGradOut, batch_stride, dim_stride) \
-    using AlignedT = AlignedTuple<weight_t, kNStepsPerThread>; \
-    using UnalignedT = UnalignedTuple<weight_t, kNStepsPerThread>; \
-    if (kNStepsPerThread == 4 && \
-        ((long)gates.data_ptr()) % 16 == 0 && \
-        ((long)output.data_ptr()) % 16 == 0 && \
-        ((long)outGrad.data_ptr()) % 16 == 0 && \
-        ((long)gateGradOut.data_ptr()) % 16 == 0 && \
-        ((long)tokenGradOut.data_ptr()) % 16 == 0) { \
-        scan_grad<AlignedT, kNThreadsPerWarp, kNWarpsPerBlock, kNChunksPerSequence><<<grid, kNThreads, kNWarpsPerBlock * sizeof(weight_t) * 2, stream>>>( \
-                reinterpret_cast<const AlignedT *>(gates.data_ptr<torch_weight_t>()), \
-                reinterpret_cast<const AlignedT *>(output.data_ptr<torch_weight_t>()), \
-                reinterpret_cast<const AlignedT *>(outGrad.data_ptr<torch_weight_t>()), \
-                reinterpret_cast<AlignedT *>(gateGradOut.data_ptr<torch_weight_t>()), \
-                reinterpret_cast<AlignedT *>(tokenGradOut.data_ptr<torch_weight_t>()), \
-                batch_stride, dim_stride \
-            ); \
-    } else { \
-        scan_grad<UnalignedT, kNThreadsPerWarp, kNWarpsPerBlock, kNChunksPerSequence><<<grid, kNThreads, kNWarpsPerBlock * sizeof(weight_t) * 2, stream>>>( \
-                reinterpret_cast<const UnalignedT *>(gates.data_ptr<torch_weight_t>()), \
-                reinterpret_cast<const UnalignedT *>(output.data_ptr<torch_weight_t>()), \
-                reinterpret_cast<const UnalignedT *>(outGrad.data_ptr<torch_weight_t>()), \
-                reinterpret_cast<UnalignedT *>(gateGradOut.data_ptr<torch_weight_t>()), \
-                reinterpret_cast<UnalignedT *>(tokenGradOut.data_ptr<torch_weight_t>()), \
-                batch_stride, dim_stride \
-            ); \
-    }
-
-template <typename weight_t, typename torch_weight_t>
-void
-warpscan_grad(const at::Tensor &gates, const at::Tensor &output, const at::Tensor &outGrad,
-              const at::Tensor& gateGradOut, const at::Tensor& tokenGradOut) {
-    const auto strides = gates.strides();
-    const int batch_stride = strides[0];
-    const int dim_stride = strides[1];
-    CHECK_STRIDE(gates);
-    CHECK_STRIDE(output);
-    CHECK_STRIDE(outGrad);
-    CHECK_STRIDE(gateGradOut);
-    CHECK_STRIDE(tokenGradOut);
-
-    const auto sizes = gates.sizes();
-    const int batch_size = sizes[0];
-    const int dim = sizes[1];
-    const int seqlen = sizes[2];
-
-    auto stream = at::cuda::getCurrentCUDAStream().stream();
-    dim3 grid(batch_size, dim);
-    constexpr int kNThreadsPerWarp = 32;
-
-    if (seqlen == 32) {
-        constexpr int kNStepsPerThread = 1;
-        constexpr int kNWarpsPerBlock = 1;
-        int kNThreads = seqlen / kNStepsPerThread;
-        constexpr int kNChunksPerSequence = 1;
-        DISPATCH_SCAN_GRAD(weight_t, kNStepsPerThread, kNThreadsPerWarp, kNWarpsPerBlock,
-            kNChunksPerSequence, grid, kNThreads, stream,
-            gates, output, outGrad, gateGradOut, tokenGradOut,
-            batch_stride, dim_stride);
-    } else if (seqlen == 64) {
-        constexpr int kNStepsPerThread = 2;
-        constexpr int kNWarpsPerBlock = 1;
-        constexpr int kNChunksPerSequence = 1;
-        int kNThreads = seqlen / kNStepsPerThread / kNChunksPerSequence;
-        DISPATCH_SCAN_GRAD(weight_t, kNStepsPerThread, kNThreadsPerWarp, kNWarpsPerBlock,
-            kNChunksPerSequence, grid, kNThreads, stream,
-            gates, output, outGrad, gateGradOut, tokenGradOut,
-            batch_stride, dim_stride);
-    } else if (seqlen == 128) {
-        constexpr int kNStepsPerThread = 1;
-        constexpr int kNWarpsPerBlock = 4;
-        int kNThreads = seqlen / kNStepsPerThread;
-        constexpr int kNChunksPerSequence = 1;
-        DISPATCH_SCAN_GRAD(weight_t, kNStepsPerThread, kNThreadsPerWarp, kNWarpsPerBlock,
-            kNChunksPerSequence, grid, kNThreads, stream,
-            gates, output, outGrad, gateGradOut, tokenGradOut,
-            batch_stride, dim_stride);
-    } else if (seqlen == 256) {
-        constexpr int kNStepsPerThread = 1;
-        constexpr int kNWarpsPerBlock = 8;
-        int kNThreads = seqlen / kNStepsPerThread;
-        constexpr int kNChunksPerSequence = 1;
-        DISPATCH_SCAN_GRAD(weight_t, kNStepsPerThread, kNThreadsPerWarp, kNWarpsPerBlock,
-            kNChunksPerSequence, grid, kNThreads, stream,
-            gates, output, outGrad, gateGradOut, tokenGradOut,
-            batch_stride, dim_stride);
-    } else if (seqlen == 512) {
-        constexpr int kNStepsPerThread = 1;
-        constexpr int kNWarpsPerBlock = 16;
-        int kNThreads = seqlen / kNStepsPerThread;
-        constexpr int kNChunksPerSequence = 1;
-        DISPATCH_SCAN_GRAD(weight_t, kNStepsPerThread, kNThreadsPerWarp, kNWarpsPerBlock,
-            kNChunksPerSequence, grid, kNThreads, stream,
-            gates, output, outGrad, gateGradOut, tokenGradOut,
-            batch_stride, dim_stride);
-    } else if (seqlen == 1024) {
-        constexpr int kNStepsPerThread = 2;
-        constexpr int kNWarpsPerBlock = 16;
-        int kNThreads = seqlen / kNStepsPerThread;
-        constexpr int kNChunksPerSequence = 1;
-        DISPATCH_SCAN_GRAD(weight_t, kNStepsPerThread, kNThreadsPerWarp, kNWarpsPerBlock,
-            kNChunksPerSequence, grid, kNThreads, stream,
-            gates, output, outGrad, gateGradOut, tokenGradOut,
-            batch_stride, dim_stride);
-    } else if (seqlen == 2048) {
-        constexpr int kNStepsPerThread = 2;
-        constexpr int kNWarpsPerBlock = 32;
-        int kNThreads = seqlen / kNStepsPerThread;
-        constexpr int kNChunksPerSequence = 1;
-        DISPATCH_SCAN_GRAD(weight_t, kNStepsPerThread, kNThreadsPerWarp, kNWarpsPerBlock,
-            kNChunksPerSequence, grid, kNThreads, stream,
-            gates, output, outGrad, gateGradOut, tokenGradOut,
-            batch_stride, dim_stride);
-    } else if (seqlen == 4096) {
-        constexpr int kNStepsPerThread = 4;
-        constexpr int kNWarpsPerBlock = 32;
-        int kNThreads = seqlen / kNStepsPerThread;
-        constexpr int kNChunksPerSequence = 1;
-        DISPATCH_SCAN_GRAD(weight_t, kNStepsPerThread, kNThreadsPerWarp, kNWarpsPerBlock,
-            kNChunksPerSequence, grid, kNThreads, stream,
-            gates, output, outGrad, gateGradOut, tokenGradOut,
-            batch_stride, dim_stride);
-    } else if (seqlen == 8192) {
-        constexpr int kNStepsPerThread = 4;
-        constexpr int kNWarpsPerBlock = 32;
-        constexpr int kNChunksPerSequence = 2;
-        int kNThreads = seqlen / kNStepsPerThread / kNChunksPerSequence;
-        DISPATCH_SCAN_GRAD(weight_t, kNStepsPerThread, kNThreadsPerWarp, kNWarpsPerBlock,
-            kNChunksPerSequence, grid, kNThreads, stream,
-            gates, output, outGrad, gateGradOut, tokenGradOut,
-            batch_stride, dim_stride);
-    } else if (seqlen == 16384) {
-        constexpr int kNStepsPerThread = 4;
-        constexpr int kNWarpsPerBlock = 32;
-        constexpr int kNChunksPerSequence = 4;
-        int kNThreads = seqlen / kNStepsPerThread / kNChunksPerSequence;
-        DISPATCH_SCAN_GRAD(weight_t, kNStepsPerThread, kNThreadsPerWarp, kNWarpsPerBlock,
-            kNChunksPerSequence, grid, kNThreads, stream,
-            gates, output, outGrad, gateGradOut, tokenGradOut,
-            batch_stride, dim_stride);
-    } else if (seqlen == 32768) {
-        constexpr int kNStepsPerThread = 4;
-        constexpr int kNWarpsPerBlock = 32;
-        constexpr int kNChunksPerSequence = 8;
-        int kNThreads = seqlen / kNStepsPerThread / kNChunksPerSequence;
-        DISPATCH_SCAN_GRAD(weight_t, kNStepsPerThread, kNThreadsPerWarp, kNWarpsPerBlock,
-            kNChunksPerSequence, grid, kNThreads, stream,
-            gates, output, outGrad, gateGradOut, tokenGradOut,
-            batch_stride, dim_stride);
-    } else if (seqlen == 65536) {
-        constexpr int kNStepsPerThread = 4;
-        constexpr int kNWarpsPerBlock = 32;
-        constexpr int kNChunksPerSequence = 16;
-        int kNThreads = seqlen / kNStepsPerThread / kNChunksPerSequence;
-        DISPATCH_SCAN_GRAD(weight_t, kNStepsPerThread, kNThreadsPerWarp, kNWarpsPerBlock,
-            kNChunksPerSequence, grid, kNThreads, stream,
-            gates, output, outGrad, gateGradOut, tokenGradOut,
-            batch_stride, dim_stride);
-    } else {
-        TORCH_CHECK(false && "seqlen must be a power of 2, >= 32, <= 65536");
-    }
 }
 
 void
@@ -702,13 +439,5 @@ warpscan_backward(const at::Tensor &gates, const at::Tensor &output, const at::T
     TORCH_CHECK(gates.sizes() == gateGradOut.sizes());
     TORCH_CHECK(gates.sizes() == tokenGradOut.sizes());
 
-    if (gates.scalar_type() == at::ScalarType::BFloat16) {
-        warpscan_grad<__nv_bfloat16, at::BFloat16>(gates, output, outGrad, gateGradOut, tokenGradOut);
-    } else if (gates.scalar_type() == at::ScalarType::Half) {
-        warpscan_grad<__half, at::Half>(gates, output, outGrad, gateGradOut, tokenGradOut);
-    } else if (gates.scalar_type() == at::ScalarType::Float) {
-        warpscan_grad<float, float>(gates, output, outGrad, gateGradOut, tokenGradOut);
-    } else {
-        TORCH_CHECK(false && "Unsupported tensor dtype: expecting bfloat16, float16 or float32");
-    }
+    DISPATCH_WARPSCAN(gates, outGrad, tokenGradOut, output.data_ptr(), gateGradOut.data_ptr(), true);
 }

--- a/accelerated_scan/warp.cuh
+++ b/accelerated_scan/warp.cuh
@@ -509,7 +509,7 @@ __global__ void scan_grad(
 
         Tuple gateGrad = load_shifted_tuple<Tuple, -1>(output, tupleOffset, limit);
         for (int i = 0; i < Tuple::Size; i++) {
-            gateGrad.data[i] *= accToken.data[i];
+            gateGrad.data[i] = gateGrad.data[i] * accToken.data[i];
         }
         gateGradOut[tupleOffset] = gateGrad;
 

--- a/accelerated_scan/warp.cuh
+++ b/accelerated_scan/warp.cuh
@@ -370,8 +370,7 @@ __global__ void scan_grad(
     Tuple* gateGradOut,
     Tuple* valueGradOut,
     const int batch_stride,
-    const int dim_stride,
-    const bool reverse
+    const int dim_stride
 ) {
     using weight_t = typename Tuple::Type;
 

--- a/accelerated_scan/warp.cuh
+++ b/accelerated_scan/warp.cuh
@@ -355,7 +355,7 @@ __device__ Tuple load_shifted_tuple(const Tuple* ptr, int index, int limit) {
     for (int i = 0; i < Tuple::Size; i++) {
         const int idx = index * Tuple::Size + i + offset;
         if (idx >= 0 && idx < limit * Tuple::Size) {
-            x.data[i] = rawPtr[offset];
+            x.data[i] = rawPtr[idx];
         } else {
             x.data[i] = 0.0;
         }

--- a/accelerated_scan/warp.cuh
+++ b/accelerated_scan/warp.cuh
@@ -533,16 +533,16 @@ __global__ void scan_grad(
                 reinterpret_cast<const AlignedT *>(gates.data_ptr<torch_weight_t>()), \
                 reinterpret_cast<const AlignedT *>(output.data_ptr<torch_weight_t>()), \
                 reinterpret_cast<const AlignedT *>(outGrad.data_ptr<torch_weight_t>()), \
-                reinterpret_cast<const AlignedT *>(gateGradOut.data_ptr<torch_weight_t>()), \
+                reinterpret_cast<AlignedT *>(gateGradOut.data_ptr<torch_weight_t>()), \
                 reinterpret_cast<AlignedT *>(valueGradOut.data_ptr<torch_weight_t>()), \
                 batch_stride, dim_stride \
             ); \
     } else { \
         scan_grad<UnalignedT, kNThreadsPerWarp, kNWarpsPerBlock, kNChunksPerSequence><<<grid, kNThreads, kNWarpsPerBlock * sizeof(weight_t) * 2, stream>>>( \
-                reinterpret_cast<const UnalignedT*>(gates.data_ptr<torch_weight_t>()), \
-                reinterpret_cast<const UnalignedT*>(output.data_ptr<torch_weight_t>()), \
-                reinterpret_cast<const UnalignedT*>(outGrad.data_ptr<torch_weight_t>()), \
-                reinterpret_cast<const UnalignedT*>(gateGradOut.data_ptr<torch_weight_t>()), \
+                reinterpret_cast<const UnalignedT *>(gates.data_ptr<torch_weight_t>()), \
+                reinterpret_cast<const UnalignedT *>(output.data_ptr<torch_weight_t>()), \
+                reinterpret_cast<const UnalignedT *>(outGrad.data_ptr<torch_weight_t>()), \
+                reinterpret_cast<UnalignedT *>(gateGradOut.data_ptr<torch_weight_t>()), \
                 reinterpret_cast<UnalignedT *>(valueGradOut.data_ptr<torch_weight_t>()), \
                 batch_stride, dim_stride \
             ); \

--- a/accelerated_scan/warp.cuh
+++ b/accelerated_scan/warp.cuh
@@ -552,7 +552,7 @@ template <typename weight_t, typename torch_weight_t>
 void
 warpscan_grad(const at::Tensor &gates, const at::Tensor &output, const at::Tensor &outGrad,
               const at::Tensor& gateGradOut, const at::Tensor& valueGradOut) {
-    const auto strides = tokens.strides();
+    const auto strides = gates.strides();
     const int batch_stride = strides[0];
     const int dim_stride = strides[1];
     CHECK_STRIDE(gates);
@@ -561,7 +561,7 @@ warpscan_grad(const at::Tensor &gates, const at::Tensor &output, const at::Tenso
     CHECK_STRIDE(gateGradOut);
     CHECK_STRIDE(valueGradOut);
 
-    const auto sizes = tokens.sizes();
+    const auto sizes = gates.sizes();
     const int batch_size = sizes[0];
     const int dim = sizes[1];
     const int seqlen = sizes[2];

--- a/accelerated_scan/warp.py
+++ b/accelerated_scan/warp.py
@@ -13,7 +13,7 @@ module = load_inline(
     name='warpscan',
     cpp_sources=[cpp_source],
     cuda_sources=[cuda_source],
-    functions=['warpscan_forward'],
+    functions=['warpscan_forward', 'warpscan_backward'],
     verbose=True,
     extra_cuda_cflags=[
         "-O3",

--- a/accelerated_scan/warp.py
+++ b/accelerated_scan/warp.py
@@ -7,6 +7,7 @@ cuda_source = (Path(__file__).parent / 'warp.cuh').read_text()
 
 cpp_source = """
 at::Tensor warpscan_forward(const at::Tensor &gates, const at::Tensor &tokens, const at::Tensor &out, const bool reverse);
+void warpscan_backward(const at::Tensor &gates, const at::Tensor &output, const at::Tensor &outGrad, const at::Tensor& gateGradOut, const at::Tensor& valueGradOut);
 """
 
 module = load_inline(


### PR DESCRIPTION
##### Description

This implements the backward pass as a single CUDA kernel call. This should simultaneously reduce kernel call overhead and memory I/O.

##### Benchmark

I benchmarked the time of a forward+backward operation with shape `8 x 512 x 65536` on my Titan X.
 * Old time: **67.4ms**
 * New time: **33.1ms**
 * Speedup: **~50%**

I did not bother to separate out the cost of the forward (which should be unchanged), since a forward+backward best reflects the actual calls during training of a model.

Benchmarked with this in a notebook:

```python
from accelerated_scan.warp import scan as scan_warp
from accelerated_scan.ref import scan as scan_ref
import torch

x = torch.nn.Parameter(torch.randn(8, 512, 65536).cuda()) * 0.2
y = torch.nn.Parameter(torch.randn(8, 512, 65536).cuda())
grad_out = torch.randn_like(x)

def fn():
    warp_out = scan_warp(x, y)
    warp_grad = torch.autograd.grad(warp_out, (x, y), grad_out)
    sum(x.sum().item() for x in warp_grad)

%timeit fn()
```

##### Testing

I tested against the reference implementation as follows. However, I have not run the full test suite.

```python
from accelerated_scan.warp import scan as scan_warp
from accelerated_scan.ref import scan as scan_ref
import torch

x = torch.nn.Parameter(torch.randn(8, 32, 1024).cuda()) * 0.2
y = torch.nn.Parameter(torch.randn(8, 32, 1024).cuda())
ref_out = scan_ref(x, y)
warp_out = scan_warp(x, y)
grad_out = torch.randn_like(ref_out)

ref_grad = torch.autograd.grad(ref_out, (x, y), grad_out)
warp_grad = torch.autograd.grad(warp_out, (x, y), grad_out)
for i, (actual, expected) in enumerate(zip(ref_grad, warp_grad)):
    assert torch.allclose(actual, expected, atol=1e-4), f'{i=} {actual=} {expected=}'
print('PASS')
```
