### PR TITLE
complex: fix inter-block carry in backward_scan and expand test coverage

### DIFF
--- a/tests/tests_eq_complex.py
+++ b/tests/tests_eq_complex.py
@@ -6,10 +6,24 @@ from accelerated_scan.ref import scan as scan_ref
 
 seeds = [1, 11, 22]
 seqlens = [2**i for i in range(12, 18)] + [16323, 8000, 33753, 127323]
+hard_modes = [False, True]
+def loss_real_mean(out):
+    return out.real.mean()
+
+
+def loss_last_sum(out):
+    return out[:, :, -1].real.sum() + out[:, :, -1].imag.sum()
+
+
+def loss_abs_sq_mean(out):
+    return out.abs().square().mean()
+
+
+loss_fns = [loss_real_mean, loss_last_sum, loss_abs_sq_mean]
 atol, rtol = 1e-5, 1e-4
 
 
-def init(seed, batch_size=1, dim=512, seqlen=32, requires_grad=False):
+def init(seed, batch_size=1, dim=512, seqlen=32, requires_grad=False, hard_mode=True):
     torch.manual_seed(seed)
     angle = 2 * torch.pi * torch.rand(
         batch_size,
@@ -18,7 +32,11 @@ def init(seed, batch_size=1, dim=512, seqlen=32, requires_grad=False):
         dtype=torch.float32,
         device="cuda",
     )
-    radius = 0.4 + 0.6 * torch.rand_like(angle)
+    if hard_mode:
+        # Radius near 1.0 ensures gradient doesn't vanish.
+        radius = 0.99 + 0.01 * torch.rand_like(angle)
+    else:
+        radius = 0.4 + 0.6 * torch.rand_like(angle)
     forget = torch.polar(radius, angle).to(torch.complex64).requires_grad_(requires_grad)
     inputs = torch.randn(
         batch_size,
@@ -36,9 +54,10 @@ def init(seed, batch_size=1, dim=512, seqlen=32, requires_grad=False):
 
 @pytest.mark.parametrize("seed", seeds)
 @pytest.mark.parametrize("seqlen", seqlens)
+@pytest.mark.parametrize("hard_mode", hard_modes)
 @torch.inference_mode()
-def test_complex_forward(seed, seqlen):
-    forget, inputs = init(seed, seqlen=seqlen)
+def test_complex_forward(seed, seqlen, hard_mode):
+    forget, inputs = init(seed, seqlen=seqlen, hard_mode=hard_mode)
     out = scan_complex(forget, inputs)
     out_ref = scan_ref(forget, inputs)
     torch.testing.assert_close(out, out_ref, atol=atol, rtol=rtol)
@@ -46,16 +65,22 @@ def test_complex_forward(seed, seqlen):
 
 @pytest.mark.parametrize("seed", seeds)
 @pytest.mark.parametrize("seqlen", seqlens)
-def test_complex_backward(seed, seqlen):
-    forget, inputs = init(seed, seqlen=seqlen, requires_grad=True)
-    scan_complex(forget, inputs).real.mean().backward()
+@pytest.mark.parametrize("hard_mode", hard_modes)
+@pytest.mark.parametrize("loss_fn", loss_fns)
+def test_complex_backward(seed, seqlen, hard_mode, loss_fn):
+    forget, inputs = init(seed, seqlen=seqlen, requires_grad=True, hard_mode=hard_mode)
+    out = scan_complex(forget, inputs)
+    loss = loss_fn(out)
+    loss.backward()
     forget_grad = forget.grad
     inputs_grad = inputs.grad
     del forget
     del inputs
 
-    forget_ref, inputs_ref = init(seed, seqlen=seqlen, requires_grad=True)
-    scan_ref(forget_ref, inputs_ref).real.mean().backward()
+    forget_ref, inputs_ref = init(seed, seqlen=seqlen, requires_grad=True, hard_mode=hard_mode)
+    out_ref = scan_ref(forget_ref, inputs_ref)
+    loss_ref = loss_fn(out_ref)
+    loss_ref.backward()
 
     torch.testing.assert_close(forget_grad, forget_ref.grad, atol=atol, rtol=rtol)
     torch.testing.assert_close(inputs_grad, inputs_ref.grad, atol=atol, rtol=rtol)


### PR DESCRIPTION
Hi, great repo!

I was taking a look at the complex scan code and noticed incorrect gradients in the backward pass. I tracked this down to the inter-block carry logic in`accelerated_scan/complex.py` 

In particular  the current code scales the intra-block scan:
```
state_mul_r, state_mul_i = complex_mul(d_inputs_r, d_inputs_i, state_f_r, state_f_i)
d_inputs_r, d_inputs_i = state_mul_r + state_x_r, state_mul_i + state_x_i
```
This computes `result[t] = local_scan[t] * state_f + state_x` but the backward recursion should be:
`result[t] = local_scan[t] + state_x * f[t]`

I checked the existing tests and I think the bug was hidden because gradients decay quickly with very small r, so any block issues got masked. I added some additional tests for better coverage. Happy to discuss if you have any comments or questions.

Summary:
   - Fix state carry accumulation logic and remove unused state_f
   - Add documentation explaining the adjoint recursion
   - Add hard_mode tests (r≈1) to stress long-range gradient flow
   - Add varied loss functions to test different gradient patterns